### PR TITLE
Updated sample machine config manifest for crio

### DIFF
--- a/test_resources/default/machine_config.yaml
+++ b/test_resources/default/machine_config.yaml
@@ -15,3 +15,4 @@ spec:
             [Service]
             Environment="ENABLE_PROFILE_UNIX_SOCKET=true"
           name: 10-mco-profile-unix-socket.conf
+        name: crio.service


### PR DESCRIPTION
Updated missing name parameter in the sample crio machine config manifest.