### PR TITLE
Add kube-rbac-proxy for authx

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ List of requrired parameters to be passed to the agent:
 
 It accepts requests for the following endpoints:
 
-- Kubelet + CRIO Profiling: `/pprof`
-- Status update: `/status`
+- Kubelet + CRIO Profiling: `/node-observability-pprof`
+- Status update: `/node-observability-status`
 
 The agent doesn't accept concurrent requests: only one profiling request can run at a time. 
-Therefore, `/status` as well as `/pprof` will return a 409 error if the agent is already running a profiling request. 
-In case of error, `/status` and `/pprof` will return a 500 error. The agent will remain in error until an admin has cleared the `agent.err` file that is stored in the `storageFolder`. 
+Therefore, `/node-observability-status` as well as `/node-observability-pprof` will return a 409 error if the agent is already running a profiling request. 
+In case of error, `/node-observability-status` and `/node-observability-pprof` will return a 500 error. The agent will remain in error until an admin has cleared the `agent.err` file that is stored in the `storageFolder`. 
 
 ## Run the agent
 

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -62,7 +62,7 @@ func TestStatus(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			r := httptest.NewRequest("GET", "http://localhost/status", nil)
+			r := httptest.NewRequest("GET", "http://localhost/node-observability-status", nil)
 			w := httptest.NewRecorder()
 			h := NewHandlers("abc", "/tmp", "/tmp/fakeSocket", "127.0.0.1")
 			var cur uuid.UUID
@@ -198,7 +198,7 @@ func TestHandleProfiling(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			h := NewHandlers("abc", "/tmp", "/tmp/fakeSocket", "127.0.0.1")
-			r := httptest.NewRequest("GET", "http://localhost/status", nil)
+			r := httptest.NewRequest("GET", "http://localhost/node-observability-status", nil)
 			w := httptest.NewRecorder()
 			if tc.serverState == "busy" {
 				_, _, err := h.stateLocker.Lock()

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -10,7 +10,7 @@ func setupRoutes(cfg Config) *mux.Router {
 
 	h := handlers.NewHandlers(cfg.Token, cfg.StorageFolder, cfg.CrioUnixSocket, cfg.NodeIP)
 	r := mux.NewRouter()
-	r.HandleFunc("/pprof", h.HandleProfiling)
-	r.HandleFunc("/status", h.Status)
+	r.HandleFunc("/node-observability-pprof", h.HandleProfiling)
+	r.HandleFunc("/node-observability-status", h.Status)
 	return r
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -9,6 +9,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const loopback = "127.0.0.1"
+
 var slog = logrus.WithField("module", "server")
 
 // Config holds the parameters necessary for the HTTP server, and agent in general need to run
@@ -32,13 +34,13 @@ func Start(cfg Config) {
 
 	httpServer := &http.Server{
 		Handler:      router,
-		Addr:         fmt.Sprintf(":%d", cfg.Port),
+		Addr:         fmt.Sprintf("%s:%d", loopback, cfg.Port),
 		TLSConfig:    tlsConfig,
 		ReadTimeout:  40 * time.Second,
 		WriteTimeout: 40 * time.Second,
 	}
 
-	slog.Infof("listening on http://:%d", cfg.Port)
+	slog.Infof("listening on http://%s:%d", loopback, cfg.Port)
 	slog.Infof("targeting node %s", cfg.NodeIP)
 
 	panic(httpServer.ListenAndServe())

--- a/test_resources/default/daemonset_patch.yaml
+++ b/test_resources/default/daemonset_patch.yaml
@@ -9,14 +9,13 @@ spec:
       - name: node-observability-agent
         securityContext:
           privileged: true 
-      #   volumeMounts:
-      #   - name: profiling-data
-      #     mountPath: /host/tmp/pprofs
-      #     readOnly: false
-      # volumes:
-      # - name: profiling-data
-      #   persistentVolumeClaim:
-      #     claimName: node-observability-agent-profiling
-      # - name: profiling-data
-      #   hostPath:
-      #     path: /tmp/data
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:9000/"
+        - "--logtostderr=true"
+        - "--v=2"
+        # TODO:
+        # - "--tls-cert-file=/var/run/secrets/serving-cert/tls.crt"
+        # - "--tls-private-key-file=/var/run/secrets/serving-cert/tls.key"

--- a/test_resources/default/rbac.yaml
+++ b/test_resources/default/rbac.yaml
@@ -40,6 +40,14 @@ rules:
   verbs: ["get", "list"]
 - nonResourceURLs: [ "/debug/pprof/profile"]
   verbs: ["get"]
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: ["create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/test_resources/default/service.yaml
+++ b/test_resources/default/service.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   clusterIP: None
   ports:
-      # By default and for convenience, the `targetPort` is set to the same value as the `port` field.
-    - protocol: TCP
-      port: 80
-      targetPort: 9000
+  - protocol: TCP
+    port: 8443
+    targetPort: 8443


### PR DESCRIPTION
The agent isn't directly exposed anymore. It now binds on 127.0.0.1 in its net namespace.
kube-rbac-proxy performs token review of requests. The client needs the following RBAC:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: kube-rbac-proxy-client
rules:
- nonResourceURLs: ["/node-observability-status"]
  verbs: ["get"]
- nonResourceURLs: ["/node-observability-pprof"]
  verbs: ["get"]
```