### PR TITLE
Inject git meta during build with -ldflags

### DIFF
--- a/cmd/node-observability-agent/main.go
+++ b/cmd/node-observability-agent/main.go
@@ -11,11 +11,10 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/openshift/node-observability-agent/pkg/server"
+	ver "github.com/openshift/node-observability-agent/pkg/version"
 )
 
 var (
-	version       = "unknown"
-	app           = "node-observability-agent"
 	node          = os.Getenv("NODE_IP")
 	port          = flag.Int("port", 9000, "server port to listen on (default: 9000)")
 	storageFolder = flag.String("storage", "/tmp/pprofs/", "folder to which the pprof files are saved")
@@ -23,14 +22,13 @@ var (
 	crioSocket    = flag.String("crioUnixSocket", "/var/run/crio/crio.sock", "file referring to the unix socket to be used for CRIO profiling")
 	logLevel      = flag.String("loglevel", "info", "log level")
 	versionFlag   = flag.Bool("v", false, "print version")
-	appVersion    = fmt.Sprintf("%s %s", app, version)
 )
 
 func main() {
 	flag.Parse()
 
 	if *versionFlag {
-		fmt.Println(appVersion)
+		fmt.Println(ver.MakeVersionString())
 		os.Exit(0)
 	}
 
@@ -44,7 +42,7 @@ func main() {
 		lvl = log.InfoLevel
 	}
 	log.SetLevel(lvl)
-	log.Infof("Starting %s at log level %s", appVersion, *logLevel)
+	log.Infof("Starting %s at log level %s", ver.MakeVersionString(), *logLevel)
 
 	checkParameters(*tokenFile, node, *storageFolder, *crioSocket)
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,17 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	versionFromGit = "unknown"
+	commitFromGit  = "unknown"
+	buildDate      = "unknown"
+)
+
+func MakeVersionString() string {
+	return fmt.Sprintf("node-observability-agent version: %q, commit: %q, build date: %q, go version: %q, GOOS: %q, GOARCH: %q",
+		versionFromGit, commitFromGit, buildDate, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+}


### PR DESCRIPTION
```
$ git tag v0.0.1
$ make build
$ ./bin/node-observability-agent -v
node-observability-agent version: "v0.0.1-0-g9eb0d0a", commit: "9eb0d0a", build date: "2022-04-14T09:04:39Z", go version: "go1.17.6", GOOS: "linux", GOARCH: "amd64"
```