### PR TITLE
Revert CRIO on http

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,6 @@ RUN go build -ldflags "-X main.version=${VERSION}" -mod vendor -o node-observabi
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
-RUN mkdir /run/node-observability && \
-    chgrp -R 0 /run/node-observability && \
-    chmod -R g=u /run/node-observability
-
 COPY --from=builder /opt/app-root/node-observability-agent /usr/bin/
 
 ENTRYPOINT ["sh", "-c", "node-observability-agent --tokenFile /var/run/secrets/kubernetes.io/serviceaccount/token --storage /host/tmp/pprofs/"]

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -11,8 +11,4 @@ LABEL io.k8s.display-name="OpenShift NodeObservabilityAgent" \
       io.k8s.description="Collects node profiling data" \
       io.openshift.tags="openshift,nodeobservability,nodeobservabilityagent"
 
-RUN mkdir /run/node-observability && \
-    chgrp -R 0 /run/node-observability && \
-    chmod -R g=u /run/node-observability
-
 COPY --from=builder /go/src/github.com/openshift/node-observability-agent/bin/node-observability-agent /usr/bin/

--- a/cmd/node-observability-agent/main_test.go
+++ b/cmd/node-observability-agent/main_test.go
@@ -11,6 +11,7 @@ type TestCase struct {
 	caCertFile    string
 	nodeIP        string
 	storageFolder string
+	crioSocket    string
 	expectPanic   bool
 }
 
@@ -190,6 +191,36 @@ func TestCheckParameters(t *testing.T) {
 		}
 	}()
 
+	validSocket := "/tmp/aSocket"
+	_, err = os.Create(validSocket)
+	if err != nil {
+		t.Error(err)
+	}
+	err = os.Chmod(validSocket, 0755)
+	if err != nil {
+		t.Error(err)
+	}
+	invalidSocket := "/tmp/noSocket"
+	unWriteableSocket := "/tmp/unWriteableSocket"
+	_, err = os.Create(unWriteableSocket)
+	if err != nil {
+		t.Error(err)
+	}
+	err = os.Chmod(unWriteableSocket, 0444)
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		if os.Remove(validSocket) != nil {
+			t.Error(err)
+		}
+	}()
+	defer func() {
+		if os.Remove(unWriteableSocket) != nil {
+			t.Error(err)
+		}
+	}()
+
 	validStorageFolder := "/tmp/aFolder"
 	err = os.Mkdir(validStorageFolder, 0755)
 	if err != nil {
@@ -242,6 +273,7 @@ func TestCheckParameters(t *testing.T) {
 			caCertFile:    validCACertFile,
 			nodeIP:        "127.0.0.1",
 			storageFolder: validStorageFolder,
+			crioSocket:    validSocket,
 			expectPanic:   false,
 		},
 		{
@@ -250,6 +282,7 @@ func TestCheckParameters(t *testing.T) {
 			caCertFile:    validCACertFile,
 			nodeIP:        "127.0.0.1",
 			storageFolder: validStorageFolder,
+			crioSocket:    validSocket,
 			expectPanic:   true,
 		},
 		{
@@ -258,6 +291,7 @@ func TestCheckParameters(t *testing.T) {
 			caCertFile:    validCACertFile,
 			nodeIP:        "127.0.0.1",
 			storageFolder: validStorageFolder,
+			crioSocket:    validSocket,
 			expectPanic:   true,
 		},
 		{
@@ -266,6 +300,7 @@ func TestCheckParameters(t *testing.T) {
 			caCertFile:    validCACertFile,
 			nodeIP:        " 1000.40.210.253",
 			storageFolder: validStorageFolder,
+			crioSocket:    validSocket,
 			expectPanic:   true,
 		},
 		{
@@ -274,6 +309,7 @@ func TestCheckParameters(t *testing.T) {
 			caCertFile:    validCACertFile,
 			nodeIP:        "127.0.0.1",
 			storageFolder: invalidStorageFolder,
+			crioSocket:    validSocket,
 			expectPanic:   true,
 		},
 		{
@@ -282,6 +318,25 @@ func TestCheckParameters(t *testing.T) {
 			caCertFile:    validCACertFile,
 			nodeIP:        "127.0.0.1",
 			storageFolder: unWriteableStorageFolder,
+			crioSocket:    validSocket,
+			expectPanic:   true,
+		},
+		{
+			name:          "crio socket file doesnt exist, error",
+			tokenFile:     validTokenFile,
+			caCertFile:    validCACertFile,
+			nodeIP:        "127.0.0.1",
+			storageFolder: validStorageFolder,
+			crioSocket:    invalidSocket,
+			expectPanic:   true,
+		},
+		{
+			name:          "crio socket file is not writable, error",
+			tokenFile:     validTokenFile,
+			caCertFile:    validCACertFile,
+			nodeIP:        "127.0.0.1",
+			storageFolder: validStorageFolder,
+			crioSocket:    unWriteableSocket,
 			expectPanic:   true,
 		},
 		{
@@ -290,6 +345,7 @@ func TestCheckParameters(t *testing.T) {
 			caCertFile:    invalidCACertFile,
 			nodeIP:        "127.0.0.1",
 			storageFolder: validStorageFolder,
+			crioSocket:    validSocket,
 			expectPanic:   true,
 		},
 		{
@@ -298,6 +354,7 @@ func TestCheckParameters(t *testing.T) {
 			caCertFile:    unReadableCAFile,
 			nodeIP:        "127.0.0.1",
 			storageFolder: validStorageFolder,
+			crioSocket:    validSocket,
 			expectPanic:   true,
 		},
 	}
@@ -321,5 +378,5 @@ func checkPanic(t *testing.T, tc TestCase) {
 			}
 		}
 	}()
-	checkParameters(tc.tokenFile, tc.nodeIP, tc.storageFolder, tc.caCertFile)
+	checkParameters(tc.tokenFile, tc.nodeIP, tc.storageFolder, tc.crioSocket, tc.caCertFile)
 }

--- a/pkg/connectors/cmd_wrapper.go
+++ b/pkg/connectors/cmd_wrapper.go
@@ -1,0 +1,37 @@
+package connectors
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+// CmdWrapper wrap a exec.Cmd, or its fake
+type CmdWrapper interface {
+	// Prepare sets the command and its parameters that are wrapped by CmdWrapper
+	Prepare(command string, params []string)
+	// CmdExec executes the command wrapped by CmdWrapper
+	CmdExec() (string, error)
+}
+
+// Connector represents a command being prepared to be run
+type Connector struct {
+	cmd *exec.Cmd
+}
+
+// Prepare sets the command and parameters to be called
+func (c *Connector) Prepare(command string, params []string) {
+	c.cmd = exec.Command(command, params...)
+}
+
+// CmdExec runs the command on the underlying system and returns the stdout or stderr as a string
+func (c *Connector) CmdExec() (string, error) {
+	var stdout, stderr bytes.Buffer
+	c.cmd.Stdout = &stdout
+	c.cmd.Stderr = &stderr
+	err := c.cmd.Run()
+	outStr, errStr := stdout.String(), stderr.String()
+	if err != nil {
+		return errStr, err
+	}
+	return outStr, nil
+}

--- a/pkg/connectors/mock_cmd_wrapper.go
+++ b/pkg/connectors/mock_cmd_wrapper.go
@@ -1,0 +1,44 @@
+//build: +fake
+
+package connectors
+
+import "os/exec"
+
+// FakeConnector is a structure that holds the shell command to fake-run, its parameters
+// as well as a Flag, that helps orient the behavior of the mock
+type FakeConnector struct {
+	command string
+	params  []string
+	Flag    ErrorFlag
+}
+
+// ErrorFlag values can be NoError, SocketErr or WriteErr
+type ErrorFlag string
+
+const (
+	// NoError instructs the FakeConnector to return without errors
+	NoError ErrorFlag = ""
+	// SocketErr instructs the FakeConnector to return an error related to the curl command execution
+	SocketErr ErrorFlag = "socket-error"
+	// WriteErr instructs the FakeConnector to return an error related to the storage of curl output to file
+	WriteErr ErrorFlag = "write-error"
+)
+
+// Prepare stores the command and parameters to be used by FakeConnector, preparing the call to CmdExec
+// Implementation of cmdWrapper.Prepare
+func (c *FakeConnector) Prepare(command string, params []string) {
+	c.command = command
+	c.params = params
+}
+
+// CmdExec implements the cmdWrapper.CmdExec and returns fake responses based on FakeConnector.Flag
+func (c *FakeConnector) CmdExec() (string, error) {
+	if c.Flag == SocketErr {
+		return "curl: (7) Couldn't connect to server", &exec.ExitError{}
+	}
+
+	if c.Flag == WriteErr {
+		return "curl: (23) Failure writing output to destination", &exec.ExitError{}
+	}
+	return "", nil
+}

--- a/pkg/handlers/crio_profiling_handler.go
+++ b/pkg/handlers/crio_profiling_handler.go
@@ -2,46 +2,30 @@ package handlers
 
 import (
 	"fmt"
-	"net/http"
 	"time"
 
+	"github.com/openshift/node-observability-agent/pkg/connectors"
 	"github.com/openshift/node-observability-agent/pkg/runs"
 )
 
-// ProfileCrio calls /debug/pprof/profile on the h.NodeIP
-// crio profiling over http needs to be enabled before attempting
-// This call requires access to the host network namespace
-func (h *Handlers) profileCrio(uid string, client *http.Client) runs.ProfilingRun {
-	url := "http://127.0.0.1:6060/debug/pprof/profile"
+// ProfileCrio calls /debug/pprof/profile on the h.NodeIP, through the unix socket,
+// thus triggering a CRIO profiling on that node.
+// This call requires access to the host socket, which is passed to the agent in parameter crioSocket
+func (h *Handlers) profileCrio(uid string, cmd connectors.CmdWrapper) runs.ProfilingRun {
+	//curl --unix-socket /var/run/crio/crio.sock http://localhost/debug/pprof/profile > /mnt/prof.out
+
 	run := runs.ProfilingRun{
 		Type:      runs.CrioRun,
 		BeginTime: time.Now(),
 	}
 
-	resp, err := client.Get(url)
-	if err != nil {
-		run.EndTime = time.Now()
-		run.Error = fmt.Sprintf("error with HTTP request for crio profiling %s: %v", url, err)
-		return run
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		run.EndTime = time.Now()
-		run.Error = fmt.Sprintf("error with HTTP request for crio profiling %s: statusCode %d", url, resp.StatusCode)
-		return run
-	}
-
-	errFile := h.fileHandler(uid, "crio", &resp.Body)
-	if errFile != nil {
-		run.EndTime = time.Now()
-		run.Error = fmt.Sprintf("error fileHandler - crio profiling for node %s: %s", "127.0.0.1", errFile)
-		return run
-	}
-
+	message, err := cmd.CmdExec()
 	run.EndTime = time.Now()
-	run.Successful = true
-
+	if err != nil {
+		run.Error = fmt.Sprintf("error running CRIO profiling :\n%s", message)
+	} else {
+		run.Successful = true
+		hlog.Infof("CRIO profiling successful, %s", message)
+	}
 	return run
 }

--- a/pkg/handlers/crio_profiling_handler_test.go
+++ b/pkg/handlers/crio_profiling_handler_test.go
@@ -17,10 +17,9 @@ const (
 
 func TestProfileCrio(t *testing.T) {
 	testCases := []struct {
-		name       string
-		client     *http.Client
-		storageDir string
-		expected   runs.ProfilingRun
+		name     string
+		client   *http.Client
+		expected runs.ProfilingRun
 	}{
 		{
 			name: "CrioProfiling passes, ProfileRun returned",
@@ -34,7 +33,6 @@ func TestProfileCrio(t *testing.T) {
 					Header: make(http.Header),
 				}
 			}),
-			storageDir: "/tmp",
 			expected: runs.ProfilingRun{
 				Type:       runs.CrioRun,
 				Successful: true,
@@ -50,7 +48,6 @@ func TestProfileCrio(t *testing.T) {
 					Header: make(http.Header),
 				}
 			}),
-			storageDir: "/tmp",
 			expected: runs.ProfilingRun{
 				Type:       runs.CrioRun,
 				Successful: false,
@@ -67,7 +64,6 @@ func TestProfileCrio(t *testing.T) {
 					Header: make(http.Header),
 				}
 			}),
-			storageDir: "/inexistingFolder",
 			expected: runs.ProfilingRun{
 				Type:       runs.CrioRun,
 				Successful: false,
@@ -77,7 +73,7 @@ func TestProfileCrio(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			h := NewHandlers("abc", x509.NewCertPool(), tc.storageDir, "127.0.0.1")
+			h := NewHandlers("abc", x509.NewCertPool(), "/tmp", "127.0.0.1")
 
 			pr := h.profileCrio("1234", tc.client)
 			if tc.expected.Type != pr.Type {

--- a/pkg/handlers/crio_profiling_handler_test.go
+++ b/pkg/handlers/crio_profiling_handler_test.go
@@ -1,38 +1,23 @@
 package handlers
 
 import (
-	"bytes"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"testing"
 
+	"github.com/openshift/node-observability-agent/pkg/connectors"
 	"github.com/openshift/node-observability-agent/pkg/runs"
-)
-
-const (
-	url = "http://127.0.0.1:6060/debug/pprof/profile"
 )
 
 func TestProfileCrio(t *testing.T) {
 	testCases := []struct {
-		name     string
-		client   *http.Client
-		expected runs.ProfilingRun
+		name      string
+		connector connectors.CmdWrapper
+		expected  runs.ProfilingRun
 	}{
 		{
-			name: "CrioProfiling passes, ProfileRun returned",
-			client: NewHTTPTestClient(func(req *http.Request) *http.Response {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					// Send response to be tested
-
-					Body: ioutil.NopCloser(bytes.NewBuffer([]byte("OK"))),
-					// Must be set to non-nil value or it panics
-					Header: make(http.Header),
-				}
-			}),
+			name:      "Curl command successful, OK",
+			connector: &connectors.FakeConnector{Flag: connectors.NoError},
 			expected: runs.ProfilingRun{
 				Type:       runs.CrioRun,
 				Successful: true,
@@ -40,42 +25,30 @@ func TestProfileCrio(t *testing.T) {
 			},
 		},
 		{
-			name: "Network error, ProfilingRun contains error",
-			client: NewHTTPTestClient(func(req *http.Request) *http.Response {
-				return &http.Response{
-					StatusCode: http.StatusBadRequest,
-					// Must be set to non-nil value or it panics
-					Header: make(http.Header),
-				}
-			}),
+			name:      "Network error on curl, ProfilingRun contains error",
+			connector: &connectors.FakeConnector{Flag: connectors.SocketErr},
 			expected: runs.ProfilingRun{
 				Type:       runs.CrioRun,
 				Successful: false,
-				Error:      fmt.Sprintf("error with HTTP request for crio profiling %s: statusCode %d", url, http.StatusBadRequest),
+				Error:      fmt.Sprintf("error running CRIO profiling :\n%s", "curl: (7) Couldn't connect to server"),
 			},
 		},
 		{
-			name: "IO error at storing result, ProfilingRun contains error",
-			client: NewHTTPTestClient(func(req *http.Request) *http.Response {
-				return &http.Response{
-					StatusCode: http.StatusBadRequest,
-					Body:       ioutil.NopCloser(bytes.NewBuffer([]byte("OK"))),
-					// Must be set to non-nil value or it panics
-					Header: make(http.Header),
-				}
-			}),
+			name:      "IO error at storing result, ProfilingRun contains error",
+			connector: &connectors.FakeConnector{Flag: connectors.WriteErr},
 			expected: runs.ProfilingRun{
 				Type:       runs.CrioRun,
 				Successful: false,
-				Error:      fmt.Sprintf("error fileHandler - crio profiling for node %s: %s", "127.0.0.1", "/tmp"),
+				Error:      fmt.Sprintf("error running CRIO profiling :\n%s", "curl: (23) Failure writing output to destination"),
 			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			h := NewHandlers("abc", x509.NewCertPool(), "/tmp", "127.0.0.1")
+			h := NewHandlers("abc", x509.NewCertPool(), "/tmp", "/tmp/fakeSocket", "127.0.0.1")
+			tc.connector.Prepare("curl", []string{"--unix-socket", h.CrioUnixSocket, "http://localhost/debug/pprof/profile", "--output", h.StorageFolder + "crio-1234.pprof"})
 
-			pr := h.profileCrio("1234", tc.client)
+			pr := h.profileCrio("1234", tc.connector)
 			if tc.expected.Type != pr.Type {
 				t.Errorf("Expecting a ProfilingRun of type %s but was %s", tc.expected.Type, pr.Type)
 			}

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -15,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 
+	"github.com/openshift/node-observability-agent/pkg/connectors"
 	"github.com/openshift/node-observability-agent/pkg/runs"
 	"github.com/openshift/node-observability-agent/pkg/statelocker"
 )
@@ -23,24 +23,26 @@ var hlog = logrus.WithField("module", "handler")
 
 // Handlers holds the parameters necessary for running the CRIO and Kubelet profiling
 type Handlers struct {
-	Token         string
-	NodeIP        string
-	StorageFolder string
-	CACerts       *x509.CertPool
-	stateLocker   statelocker.StateLocker
+	Token          string
+	NodeIP         string
+	StorageFolder  string
+	CrioUnixSocket string
+	CACerts        *x509.CertPool
+	stateLocker    statelocker.StateLocker
 }
 
 type fileType string
 
 // NewHandlers creates a new instance of Handlers from the given parameters
-func NewHandlers(token string, caCerts *x509.CertPool, storageFolder string, nodeIP string) *Handlers {
+func NewHandlers(token string, caCerts *x509.CertPool, storageFolder string, crioUnixSocket string, nodeIP string) *Handlers {
 	aStateLocker := statelocker.NewStateLock(filepath.Join(storageFolder, "agent."+string(errorFile)))
 	return &Handlers{
-		Token:         token,
-		CACerts:       caCerts,
-		NodeIP:        nodeIP,
-		StorageFolder: storageFolder,
-		stateLocker:   aStateLocker,
+		Token:          token,
+		CACerts:        caCerts,
+		NodeIP:         nodeIP,
+		StorageFolder:  storageFolder,
+		CrioUnixSocket: crioUnixSocket,
+		stateLocker:    aStateLocker,
 	}
 }
 
@@ -181,9 +183,9 @@ func (h *Handlers) HandleProfiling(w http.ResponseWriter, r *http.Request) {
 			}()
 
 			go func() {
-				client := http.DefaultClient
-				client.Transport = http.DefaultTransport
-				runResultsChan <- h.profileCrio(uid.String(), client)
+				connector := connectors.Connector{}
+				connector.Prepare("curl", []string{"--unix-socket", h.CrioUnixSocket, "http://localhost/debug/pprof/profile", "--output", filepath.Join(h.StorageFolder, "crio-"+uid.String()+".pprof")})
+				runResultsChan <- h.profileCrio(uid.String(), &connector)
 			}()
 
 			go h.processResults(uid, runResultsChan)
@@ -258,20 +260,6 @@ func (h *Handlers) processResults(uid uuid.UUID, runResultsChan chan runs.Profil
 			hlog.Fatal(err)
 		}
 	}
-}
-
-// G307 (CWE-703) - Mitigated
-// Deferring unsafe method "Close" on type "*os.File"
-func (h *Handlers) fileHandler(uid, profileType string, body *io.ReadCloser) error {
-	out, err := os.Create(filepath.Join(h.StorageFolder, profileType+"-"+uid+".pprof"))
-	if err != nil {
-		return err
-	}
-	_, err = io.Copy(out, *body)
-	if err != nil {
-		return err
-	}
-	return out.Close()
 }
 
 func writeRunToLogFile(arun runs.Run, storageFolder string) (string, error) {

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -65,7 +65,7 @@ func TestStatus(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r := httptest.NewRequest("GET", "http://localhost/node-observability-status", nil)
 			w := httptest.NewRecorder()
-			h := NewHandlers("abc", makeCACertPool(), "/tmp", "127.0.0.1")
+			h := NewHandlers("abc", makeCACertPool(), "/tmp", "/tmp/fakeSocket", "127.0.0.1")
 			var cur uuid.UUID
 			if tc.isBusy {
 				c, _, err := h.stateLocker.Lock()
@@ -198,7 +198,7 @@ func TestHandleProfiling(t *testing.T) {
 	for _, tc := range testCases {
 
 		t.Run(tc.name, func(t *testing.T) {
-			h := NewHandlers("abc", makeCACertPool(), "/tmp", "127.0.0.1")
+			h := NewHandlers("abc", makeCACertPool(), "/tmp", "/tmp/fakeSocket", "127.0.0.1")
 			r := httptest.NewRequest("GET", "http://localhost/node-observability-status", nil)
 			w := httptest.NewRecorder()
 			if tc.serverState == "busy" {
@@ -252,7 +252,7 @@ func TestHandleProfiling(t *testing.T) {
 }
 
 func TestProcessResults(t *testing.T) {
-	h := NewHandlers("abc", makeCACertPool(), "/tmp", "127.0.0.1")
+	h := NewHandlers("abc", makeCACertPool(), "/tmp", "/tmp/fakeSocket", "127.0.0.1")
 
 	crioRunOK := runs.ProfilingRun{
 		Type:       runs.CrioRun,

--- a/pkg/handlers/kubelet_profiling_handler.go
+++ b/pkg/handlers/kubelet_profiling_handler.go
@@ -2,7 +2,10 @@ package handlers
 
 import (
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/openshift/node-observability-agent/pkg/runs"
@@ -40,7 +43,7 @@ func (h *Handlers) profileKubelet(uid string, client *http.Client) runs.Profilin
 	}
 
 	defer res.Body.Close()
-	errFile := h.fileHandler(uid, "kubelet", &res.Body)
+	errFile := h.fileHandler(uid, &res.Body)
 	if errFile != nil {
 		run.EndTime = time.Now()
 		run.Error = fmt.Sprintf("error fileHandler - kubelet profiling for node %s: %s", h.NodeIP, errFile)
@@ -50,4 +53,18 @@ func (h *Handlers) profileKubelet(uid string, client *http.Client) runs.Profilin
 	run.EndTime = time.Now()
 	run.Successful = true
 	return run
+}
+
+// G307 (CWE-703) - Mitigated
+// Deferring unsafe method "Close" on type "*os.File"
+func (h *Handlers) fileHandler(uid string, body *io.ReadCloser) error {
+	out, err := os.Create(filepath.Join(h.StorageFolder, "kubelet-"+uid+".pprof"))
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(out, *body)
+	if err != nil {
+		return err
+	}
+	return out.Close()
 }

--- a/pkg/handlers/kubelet_profiling_handler_test.go
+++ b/pkg/handlers/kubelet_profiling_handler_test.go
@@ -37,7 +37,7 @@ func TestProfileKubelet(t *testing.T) {
 	}{
 		{
 			name:     "KubeletProfiling passes, ProfileRun returned",
-			handlers: NewHandlers("abc", caCertPool, "/tmp", "127.0.0.1"),
+			handlers: NewHandlers("abc", caCertPool, "/tmp", "/tmp/fakeSocket", "127.0.0.1"),
 			client: NewHTTPTestClient(func(req *http.Request) *http.Response {
 				return &http.Response{
 					StatusCode: 200,
@@ -56,7 +56,7 @@ func TestProfileKubelet(t *testing.T) {
 		},
 		{
 			name:     "HTTP request 401, ProfileRun in error",
-			handlers: NewHandlers("abc", caCertPool, "/tmp", "127.0.0.1"),
+			handlers: NewHandlers("abc", caCertPool, "/tmp", "/tmp/fakeSocket", "127.0.0.1"),
 
 			//client wouldnt be used in this case
 			client: NewHTTPTestClient(func(req *http.Request) *http.Response {
@@ -75,7 +75,7 @@ func TestProfileKubelet(t *testing.T) {
 		},
 		{
 			name:     "KubeletProfiling fails to save, ProfileRun in error",
-			handlers: NewHandlers("abc", caCertPool, "non-existent-path", "127.0.0.1"),
+			handlers: NewHandlers("abc", caCertPool, "non-existent-path", "/tmp/fakeSocket", "127.0.0.1"),
 			client: NewHTTPTestClient(func(req *http.Request) *http.Response {
 				return &http.Response{
 					StatusCode: 200,

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -8,7 +8,7 @@ import (
 
 func setupRoutes(cfg Config) *mux.Router {
 
-	h := handlers.NewHandlers(cfg.Token, cfg.CACerts, cfg.StorageFolder, cfg.NodeIP)
+	h := handlers.NewHandlers(cfg.Token, cfg.CACerts, cfg.StorageFolder, cfg.CrioUnixSocket, cfg.NodeIP)
 	r := mux.NewRouter()
 	r.HandleFunc("/node-observability-pprof", h.HandleProfiling)
 	r.HandleFunc("/node-observability-status", h.Status)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,11 +16,12 @@ var slog = logrus.WithField("module", "server")
 
 // Config holds the parameters necessary for the HTTP server, and agent in general need to run
 type Config struct {
-	Port          int
-	Token         string
-	CACerts       *x509.CertPool
-	NodeIP        string
-	StorageFolder string
+	Port           int
+	Token          string
+	CACerts        *x509.CertPool
+	NodeIP         string
+	StorageFolder  string
+	CrioUnixSocket string
 }
 
 // Start starts HTTP server with parameters in cfg structure


### PR DESCRIPTION
Not enough time to investigate why some of the nodes don't scrape the profiling info when the agents are running on the hostnetwork.