### PR TITLE
Align all Dockerfiles before TechPreview

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ RUN go build -ldflags "-X main.version=${VERSION}" -mod vendor -o node-observabi
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
 COPY --from=builder /opt/app-root/node-observability-agent /usr/bin/
-
-ENTRYPOINT ["sh", "-c", "node-observability-agent --tokenFile /var/run/secrets/kubernetes.io/serviceaccount/token --storage /host/tmp/pprofs/"]
+USER 65532:65532
+#TODO(alebedev): SET UP THE ENTRYPOINT TO THE OPERATOR BINARY!

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -12,3 +12,5 @@ LABEL io.k8s.display-name="OpenShift NodeObservabilityAgent" \
       io.openshift.tags="openshift,nodeobservability,nodeobservabilityagent"
 
 COPY --from=builder /go/src/github.com/openshift/node-observability-agent/bin/node-observability-agent /usr/bin/
+USER 65532:65532
+#TODO(alebedev): SET UP THE ENTRYPOINT TO THE OPERATOR BINARY!

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 The agent exposes port 9000 by default, unless a `--port` parameter is passed to it. 
 
-List of requrired parameters to be passed to the agent:
-- node : IP address of the node on which to perform the profiling
-- storageFolder : folder to which the pprof files are saved
-- tokenFile : file containing token to be used for kubelet profiling http request
-- crioSocket : file referring to the unix socket to be used for CRIO profiling
+List of required parameters to be passed to the agent:
+- `NODE_IP` environment variable: IP address of the node on which to perform the profiling
+- `--storage` flag : folder to which the pprof files are saved
+- `--tokenFile` flag : file containing token to be used for kubelet profiling http request
+- `--crioUnixSocket` flag : file referring to the unix socket to be used for CRIO profiling
 
 It accepts requests for the following endpoints:
 


### PR DESCRIPTION
`Dockerfile.rhel8` doesn't set any entrypoint and this is [what's expected](https://github.com/openshift/node-observability-operator/blob/main/pkg/operator/controller/nodeobservability/daemonset.go#L111) by the operator for the moment.
I really think that the entrypoint has to be set to the operator binary explicitly but just to beat the techpreview release down I prefer to just align both Dockerfiles (for local and CI builds) for the moment.

This will help to align the CPaaS built Dockerfile afterwards as, for the moment, it's copying the binary at the wrong place and sets an entrpoint.