### PR TITLE
Add root writable storage directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ RUN go build -ldflags "-X main.version=${VERSION}" -mod vendor -o node-observabi
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
+RUN mkdir /run/node-observability && \
+    chgrp -R 0 /run/node-observability && \
+    chmod -R g=u /run/node-observability
+
 COPY --from=builder /opt/app-root/node-observability-agent /usr/bin/
 USER 65532:65532
 #TODO(alebedev): SET UP THE ENTRYPOINT TO THE OPERATOR BINARY!

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -11,6 +11,10 @@ LABEL io.k8s.display-name="OpenShift NodeObservabilityAgent" \
       io.k8s.description="Collects node profiling data" \
       io.openshift.tags="openshift,nodeobservability,nodeobservabilityagent"
 
+RUN mkdir /run/node-observability && \
+    chgrp -R 0 /run/node-observability && \
+    chmod -R g=u /run/node-observability
+
 COPY --from=builder /go/src/github.com/openshift/node-observability-agent/bin/node-observability-agent /usr/bin/
 USER 65532:65532
 #TODO(alebedev): SET UP THE ENTRYPOINT TO THE OPERATOR BINARY!


### PR DESCRIPTION
Agent image is a non-root now, so running in the custom (RunAsAny user) SCC requires a storage directory which is root group writable.