### PR TITLE
http server: add unix network and graceful stop support

### DIFF
--- a/cmd/node-observability-agent/main.go
+++ b/cmd/node-observability-agent/main.go
@@ -16,14 +16,16 @@ import (
 )
 
 var (
-	node          = os.Getenv("NODE_IP")
-	port          = flag.Int("port", 9000, "server port to listen on (default: 9000)")
-	storageFolder = flag.String("storage", "/tmp/pprofs/", "folder to which the pprof files are saved")
-	tokenFile     = flag.String("tokenFile", "", "file containing token to be used for kubelet profiling http request")
-	caCertFile    = flag.String("caCertFile", "/var/run/secrets/kubernetes.io/serviceaccount/kubelet-serving-ca.crt", "file containing CAChain for verifying the TLS certificate on kubelet profiling http request")
-	crioSocket    = flag.String("crioUnixSocket", "/var/run/crio/crio.sock", "file referring to the unix socket to be used for CRIO profiling")
-	logLevel      = flag.String("loglevel", "info", "log level")
-	versionFlag   = flag.Bool("v", false, "print version")
+	node             = os.Getenv("NODE_IP")
+	port             = flag.Int("port", 9000, "server port to listen on (default: 9000)")
+	unixSocket       = flag.String("unix-socket", "/var/run/nobagent.sock", "unix socket to listen on (default: /var/run/nobagent.sock)")
+	preferUnixSocket = flag.Bool("prefer-unix-socket", false, "listen on the unix socket instead of localhost:port")
+	storageFolder    = flag.String("storage", "/tmp/pprofs/", "folder to which the pprof files are saved")
+	tokenFile        = flag.String("tokenFile", "", "file containing token to be used for kubelet profiling http request")
+	caCertFile       = flag.String("caCertFile", "/var/run/secrets/kubernetes.io/serviceaccount/kubelet-serving-ca.crt", "file containing CAChain for verifying the TLS certificate on kubelet profiling http request")
+	crioSocket       = flag.String("crioUnixSocket", "/var/run/crio/crio.sock", "file referring to the unix socket to be used for CRIO profiling")
+	logLevel         = flag.String("loglevel", "info", "log level")
+	versionFlag      = flag.Bool("v", false, "print version")
 )
 
 func main() {
@@ -46,7 +48,7 @@ func main() {
 	log.SetLevel(lvl)
 	log.Infof("Starting %s at log level %s", ver.MakeVersionString(), *logLevel)
 
-	checkParameters(*tokenFile, node, *storageFolder, *crioSocket, *caCertFile)
+	checkParameters(node, *storageFolder, *crioSocket, *caCertFile)
 
 	/* #nosec G304 tokenFile is a parameter of the agent’s go program.
 	*  Upon creation of the NodeObservability CR, the operator creates a SA for the agent, sets its RBAC,
@@ -64,36 +66,36 @@ func main() {
 		panic("Unable to read caCerts file :" + err.Error())
 	}
 
-	server.Start(server.Config{
-		Port:           *port,
-		Token:          token,
-		CACerts:        caCerts,
-		StorageFolder:  *storageFolder,
-		CrioUnixSocket: *crioSocket,
-		NodeIP:         node,
-	})
+	if err := server.Start(server.Config{
+		Port:             *port,
+		UnixSocket:       *unixSocket,
+		PreferUnixSocket: *preferUnixSocket,
+		Token:            token,
+		CACerts:          caCerts,
+		StorageFolder:    *storageFolder,
+		CrioUnixSocket:   *crioSocket,
+		NodeIP:           node,
+	}); err != nil {
+		log.Errorf("Error from server: %s", err.Error())
+	}
+	log.Info("Stopped")
 }
 
-func checkParameters(tokenFile string, nodeIP string, storageFolder string, crioUnixSocket string, caCertFile string) {
+func checkParameters(nodeIP, storageFolder, crioUnixSocket, caCertFile string) {
 	//check on configs that are passed along before starting up the server
-	//1. token is readable
-	_, err := readTokenFile(tokenFile)
-	if err != nil {
-		panic("Unable to read token file")
-	}
-	//2. nodeIP is found
+	//1. nodeIP is found
 	if nodeIP == "" || net.ParseIP(nodeIP) == nil {
-		panic("Environment variable NODE_IP not found, or doesnt contain a valid IP address")
+		panic("Environment variable NODE_IP not found, or doesn't contain a valid IP address")
 	}
-	//3. StorageFolder is accessible in readwrite
+	//2. StorageFolder is accessible in readwrite
 	if syscall.Access(storageFolder, syscall.O_RDWR) != nil {
 		panic("Unable to access the folder specified for saving the profiling data - no write permission :" + storageFolder)
 	}
-	//4. CRIO socket is accessible in readwrite
+	//3. CRIO socket is accessible in readwrite
 	if syscall.Access(crioUnixSocket, syscall.O_RDWR) != nil {
 		panic("Unable to access the the crio socket - no write permission :" + crioUnixSocket)
 	}
-	//5. CACerts file is readable
+	//4. CACerts file is readable
 	const R_OK uint32 = 4
 	if syscall.Access(caCertFile, R_OK) != nil {
 		panic("Unable to read the caCerts file :" + caCertFile)

--- a/cmd/node-observability-agent/main_test.go
+++ b/cmd/node-observability-agent/main_test.go
@@ -7,7 +7,6 @@ import (
 
 type TestCase struct {
 	name          string
-	tokenFile     string
 	caCertFile    string
 	nodeIP        string
 	storageFolder string
@@ -161,75 +160,39 @@ func TestReadTokenFile(t *testing.T) {
 	}
 }
 func TestCheckParameters(t *testing.T) {
-	// #nosec G101 this is just an empty test file
-	validTokenFile := "/tmp/aToken"
-	err := os.WriteFile(validTokenFile, []byte("abc"), 0600)
-	if err != nil {
-		t.Error(err)
-	}
-	// #nosec G101 this is just an empty test file
-	invalidTokenFile := "/tmp/noToken"
-	// #nosec G101 this is just an empty test file
-	unReadableTokenFile := "/tmp/noReadToken"
-	_, err = os.Create(unReadableTokenFile)
-	if err != nil {
-		t.Error(err)
-	}
-	err = os.Chmod(unReadableTokenFile, 0311)
-	if err != nil {
-		t.Error(err)
-	}
-
-	defer func() {
-		if os.Remove(validTokenFile) != nil {
-			t.Error(err)
-		}
-	}()
-	defer func() {
-		if os.Remove(unReadableTokenFile) != nil {
-			t.Error(err)
-		}
-	}()
-
 	validSocket := "/tmp/aSocket"
-	_, err = os.Create(validSocket)
-	if err != nil {
+	if _, err := os.Create(validSocket); err != nil {
 		t.Error(err)
 	}
-	err = os.Chmod(validSocket, 0755)
-	if err != nil {
+	if err := os.Chmod(validSocket, 0755); err != nil {
 		t.Error(err)
 	}
 	invalidSocket := "/tmp/noSocket"
 	unWriteableSocket := "/tmp/unWriteableSocket"
-	_, err = os.Create(unWriteableSocket)
-	if err != nil {
+	if _, err := os.Create(unWriteableSocket); err != nil {
 		t.Error(err)
 	}
-	err = os.Chmod(unWriteableSocket, 0444)
-	if err != nil {
+	if err := os.Chmod(unWriteableSocket, 0444); err != nil {
 		t.Error(err)
 	}
 	defer func() {
-		if os.Remove(validSocket) != nil {
+		if err := os.Remove(validSocket); err != nil {
 			t.Error(err)
 		}
 	}()
 	defer func() {
-		if os.Remove(unWriteableSocket) != nil {
+		if err := os.Remove(unWriteableSocket); err != nil {
 			t.Error(err)
 		}
 	}()
 
 	validStorageFolder := "/tmp/aFolder"
-	err = os.Mkdir(validStorageFolder, 0755)
-	if err != nil {
+	if err := os.Mkdir(validStorageFolder, 0755); err != nil {
 		t.Error(err)
 	}
 	invalidStorageFolder := "/tmp/noFolder"
 	unWriteableStorageFolder := "/tmp/unWriteableFolder"
-	err = os.Mkdir(unWriteableStorageFolder, 0555)
-	if err != nil {
+	if err := os.Mkdir(unWriteableStorageFolder, 0555); err != nil {
 		t.Error(err)
 	}
 	defer os.Remove(validStorageFolder)
@@ -240,28 +203,25 @@ func TestCheckParameters(t *testing.T) {
 	cert := "A Fake Cert Content"
 	// #nosec G101 this is just a test file, cotaining random text
 	validCACertFile := "/tmp/aCA"
-	err = os.WriteFile(validCACertFile, []byte(cert), 0400)
-	if err != nil {
+	if err := os.WriteFile(validCACertFile, []byte(cert), 0400); err != nil {
 		t.Error(err)
 	}
 	// #nosec G101 this is just an empty test file
 	unReadableCAFile := "/tmp/unReadableCA"
-	_, err = os.Create(unReadableCAFile)
-	if err != nil {
+	if _, err := os.Create(unReadableCAFile); err != nil {
 		t.Error(err)
 	}
-	err = os.Chmod(unReadableCAFile, 0100)
-	if err != nil {
+	if err := os.Chmod(unReadableCAFile, 0100); err != nil {
 		t.Error(err)
 	}
 
 	defer func() {
-		if os.Remove(validCACertFile) != nil {
+		if err := os.Remove(validCACertFile); err != nil {
 			t.Error(err)
 		}
 	}()
 	defer func() {
-		if os.Remove(unReadableCAFile) != nil {
+		if err := os.Remove(unReadableCAFile); err != nil {
 			t.Error(err)
 		}
 	}()
@@ -269,7 +229,6 @@ func TestCheckParameters(t *testing.T) {
 	testCases := []TestCase{
 		{
 			name:          "All params are OK, no errors",
-			tokenFile:     validTokenFile,
 			caCertFile:    validCACertFile,
 			nodeIP:        "127.0.0.1",
 			storageFolder: validStorageFolder,
@@ -277,26 +236,7 @@ func TestCheckParameters(t *testing.T) {
 			expectPanic:   false,
 		},
 		{
-			name:          "Token file doesnt exist, error",
-			tokenFile:     invalidTokenFile,
-			caCertFile:    validCACertFile,
-			nodeIP:        "127.0.0.1",
-			storageFolder: validStorageFolder,
-			crioSocket:    validSocket,
-			expectPanic:   true,
-		},
-		{
-			name:          "Token file is not readeable, error",
-			tokenFile:     unReadableTokenFile,
-			caCertFile:    validCACertFile,
-			nodeIP:        "127.0.0.1",
-			storageFolder: validStorageFolder,
-			crioSocket:    validSocket,
-			expectPanic:   true,
-		},
-		{
 			name:          "nodeIP is an invalid IP, error",
-			tokenFile:     validTokenFile,
 			caCertFile:    validCACertFile,
 			nodeIP:        " 1000.40.210.253",
 			storageFolder: validStorageFolder,
@@ -305,7 +245,6 @@ func TestCheckParameters(t *testing.T) {
 		},
 		{
 			name:          "storageFolder doesnt exist, error",
-			tokenFile:     validTokenFile,
 			caCertFile:    validCACertFile,
 			nodeIP:        "127.0.0.1",
 			storageFolder: invalidStorageFolder,
@@ -314,7 +253,6 @@ func TestCheckParameters(t *testing.T) {
 		},
 		{
 			name:          "storageFolder is not writable, error",
-			tokenFile:     validTokenFile,
 			caCertFile:    validCACertFile,
 			nodeIP:        "127.0.0.1",
 			storageFolder: unWriteableStorageFolder,
@@ -323,7 +261,6 @@ func TestCheckParameters(t *testing.T) {
 		},
 		{
 			name:          "crio socket file doesnt exist, error",
-			tokenFile:     validTokenFile,
 			caCertFile:    validCACertFile,
 			nodeIP:        "127.0.0.1",
 			storageFolder: validStorageFolder,
@@ -332,7 +269,6 @@ func TestCheckParameters(t *testing.T) {
 		},
 		{
 			name:          "crio socket file is not writable, error",
-			tokenFile:     validTokenFile,
 			caCertFile:    validCACertFile,
 			nodeIP:        "127.0.0.1",
 			storageFolder: validStorageFolder,
@@ -341,7 +277,6 @@ func TestCheckParameters(t *testing.T) {
 		},
 		{
 			name:          "CACert file doesnt exist, error",
-			tokenFile:     validTokenFile,
 			caCertFile:    invalidCACertFile,
 			nodeIP:        "127.0.0.1",
 			storageFolder: validStorageFolder,
@@ -350,7 +285,6 @@ func TestCheckParameters(t *testing.T) {
 		},
 		{
 			name:          "CACert file is not readeable, error",
-			tokenFile:     validTokenFile,
 			caCertFile:    unReadableCAFile,
 			nodeIP:        "127.0.0.1",
 			storageFolder: validStorageFolder,
@@ -378,5 +312,5 @@ func checkPanic(t *testing.T, tc TestCase) {
 			}
 		}
 	}()
-	checkParameters(tc.tokenFile, tc.nodeIP, tc.storageFolder, tc.crioSocket, tc.caCertFile)
+	checkParameters(tc.nodeIP, tc.storageFolder, tc.crioSocket, tc.caCertFile)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,10 +1,16 @@
 package server
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net"
 	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -16,16 +22,18 @@ var slog = logrus.WithField("module", "server")
 
 // Config holds the parameters necessary for the HTTP server, and agent in general need to run
 type Config struct {
-	Port           int
-	Token          string
-	CACerts        *x509.CertPool
-	NodeIP         string
-	StorageFolder  string
-	CrioUnixSocket string
+	Port             int
+	UnixSocket       string
+	PreferUnixSocket bool
+	Token            string
+	CACerts          *x509.CertPool
+	NodeIP           string
+	StorageFolder    string
+	CrioUnixSocket   string
 }
 
 // Start starts HTTP server with parameters in cfg structure
-func Start(cfg Config) {
+func Start(cfg Config) error {
 	router := setupRoutes(cfg)
 
 	// Clients must use TLS 1.2 or higher
@@ -41,8 +49,38 @@ func Start(cfg Config) {
 		WriteTimeout: 40 * time.Second,
 	}
 
-	slog.Infof("listening on http://%s:%d", loopback, cfg.Port)
-	slog.Infof("targeting node %s", cfg.NodeIP)
+	network := "tcp"
+	addr := net.JoinHostPort(loopback, strconv.Itoa(cfg.Port))
+	if cfg.PreferUnixSocket {
+		network = "unix"
+		addr = cfg.UnixSocket
+	}
 
-	panic(httpServer.ListenAndServe())
+	// gracefully shutdown HTTP server
+	idleConnClosed := make(chan struct{})
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
+		slog.Info("Received signal: ", <-sigCh)
+		if err := httpServer.Shutdown(context.Background()); err != nil {
+			slog.Errorf("Failed to gracefully shut down the server: %s", err.Error())
+		}
+		close(sigCh)
+		close(idleConnClosed)
+	}()
+
+	slog.Infof("Start listening on %s://%s", network, addr)
+	slog.Infof("Targeting node %s", cfg.NodeIP)
+
+	ln, err := net.Listen(network, addr)
+	if err != nil {
+		return fmt.Errorf("failed on listen: %w", err)
+	}
+	if err := httpServer.Serve(ln); err != http.ErrServerClosed {
+		return fmt.Errorf("failed on serve: %w", err)
+	}
+
+	<-idleConnClosed
+
+	return nil
 }


### PR DESCRIPTION
This PR adds:

- ability to listen on the unix domain socket if `--prefer-unix-socket` flag is set. This feature allows to not occupy a port, maybe helpful in some scenarios (`hostnetwork` usage).
- ability to stop gracefully, allowing the ongoing connections to close gracefully in case of a termination signal

Changes in the unit tests are related to a fact that the reading of the token was deduplicated - before it was done in `checkParameters` function and just after it, now it's done only once.
